### PR TITLE
Use vs_module_defs instead of compiler directives

### DIFF
--- a/pestutils/dimvar_c.f90
+++ b/pestutils/dimvar_c.f90
@@ -4,12 +4,9 @@ module dimvar_c
   implicit none
 
   integer(c_int), bind(C, name="LENFILENAME") :: LENFILENAME_C = LENFILENAME
-  !DIR$ ATTRIBUTES DLLEXPORT :: LENFILENAME
 
   integer(c_int), bind(C, name="LENMESSAGE") :: LENMESSAGE_C = LENMESSAGE
-  !DIR$ ATTRIBUTES DLLEXPORT :: LENMESSAGE
 
   integer(c_int), bind(C, name="LENGRIDNAME") :: LENGRIDNAME_C = LENGRIDNAME
-  !DIR$ ATTRIBUTES DLLEXPORT :: LENGRIDNAME
 
 end module dimvar_c

--- a/pestutils/funcproc1.f90
+++ b/pestutils/funcproc1.f90
@@ -1,7 +1,6 @@
 integer (kind=c_int) function inquire_modflow_binary_file_specs(FileIn,FileOut,isim,                          &
                                                    itype,iprec,narray,ntime)                     &
                  bind(C,name="inquire_modflow_binary_file_specs")
-!DIR$ ATTRIBUTES DLLEXPORT :: inquire_modflow_binary_file_specs
 
 ! -- This function reports some of the details of a MODFLOW-written binary file. This file may be single or double
 !    precision. It may be a system state or budget file.
@@ -412,7 +411,6 @@ end function inquire_modflow_binary_file_specs
 
 integer (kind=c_int) function retrieve_error_message(errormessage) &
                 bind(c, name="retrieve_error_message")
-!DIR$ ATTRIBUTES DLLEXPORT :: retrieve_error_message
 
 
 ! -- This function retrieves a previously-recorded error message.
@@ -443,7 +441,6 @@ end function retrieve_error_message
 integer (kind=c_int) function install_structured_grid(gridname,ncol,nrow,nlay,icorner,    &
                                       e0,n0,rotation,delr,delc)                           &
                  bind(c,name="install_structured_grid")
-!DIR$ ATTRIBUTES DLLEXPORT :: install_structured_grid
 
 ! -- This function installs specifications for a structured grid.
 
@@ -605,7 +602,6 @@ end function install_structured_grid
 
 integer (kind=c_int) function uninstall_structured_grid(gridname)               &
                  bind(c,name="uninstall_structured_grid")
-!DIR$ ATTRIBUTES DLLEXPORT :: uninstall_structured_grid
 
 ! -- This function uninstalls a previously installed set of structured grid specifications.
 
@@ -666,7 +662,6 @@ end function uninstall_structured_grid
 
 integer (kind=c_int) function free_all_memory() &
                  bind(c,name="free_all_memory")
-!DIR$ ATTRIBUTES DLLEXPORT :: free_all_memory
 
 ! -- This function deallocates all memory that is being used.
 
@@ -734,7 +729,6 @@ integer (kind=c_int) function interp_from_structured_grid(                   &
                              npts,ecoord,ncoord,layer,                       &
                              nproctime,simtime,simstate)                     &
                  bind(c,name="interp_from_structured_grid")
-!DIR$ ATTRIBUTES DLLEXPORT :: interp_from_structured_grid
 
 ! -- This function performs spatial interpolation from a structured grid to a set of points.
 
@@ -1072,7 +1066,6 @@ integer (kind=c_int) function interp_to_obstime(                               &
                              interpthresh,how_extrap,time_extrap,nointerpval,  &
                              nobs,obspoint,obstime,obssimval)                  &
                  bind(c,name="interp_to_obstime")
-!DIR$ ATTRIBUTES DLLEXPORT :: interp_to_obstime
 
 ! -- This function performs temporal interpolation for simulation times to observation times.
 ! -- Note that observation times do not need to be supplied in increasing order for each
@@ -1239,7 +1232,6 @@ end function interp_to_obstime
 integer (kind=c_int) function install_mf6_grid_from_file(gridname,grbfile,        &
                               idis,ncells,ndim1,ndim2,ndim3)                      &
                  bind(c,name="install_mf6_grid_from_file")
-!DIR$ ATTRIBUTES DLLEXPORT :: install_mf6_grid_from_file
 
 ! -- This function installs specifications for a MF6 grid from the contents of a GRB file.
 
@@ -1615,7 +1607,6 @@ end function install_mf6_grid_from_file
 
 integer (kind=c_int) function uninstall_mf6_grid(gridname)            &
                  bind(c,name="uninstall_mf6_grid")
-!DIR$ ATTRIBUTES DLLEXPORT :: uninstall_mf6_grid
 
 ! -- This function uninstalls a previously installed mf6 grid specification.
 
@@ -1682,7 +1673,6 @@ integer (kind=c_int) function calc_mf6_interp_factors(gridname,        &
                               factorfile, factorfiletype,              &
                               blnfile,interp_success)                  &
                  bind(c,name="calc_mf6_interp_factors")
-!DIR$ ATTRIBUTES DLLEXPORT :: calc_mf6_interp_factors
 
 ! -- This function calculates interpolation factors from a MODFLOW 6 DIS or DISV
 !    grid to a set of user-supplied points.
@@ -2334,7 +2324,6 @@ integer (kind=c_int) function interp_from_mf6_depvar_file(             &
                  ntime,vartype,interpthresh,reapportion,nointerpval,   &
                  npts,nproctime,simtime,simstate)                      &
                  bind(c,name="interp_from_mf6_depvar_file")
-!DIR$ ATTRIBUTES DLLEXPORT :: interp_from_mf6_depvar_file
 
 ! -- This function interpolates to a set of points using previously-calculated
 !    interpolation factors.
@@ -2657,7 +2646,6 @@ integer (kind=c_int) function extract_flows_from_cbc_file(     &
                  ntime,nproctime,                              &
                  timestep,stressperiod,simtime,simflow)        &
                  bind(c,name="extract_flows_from_cbc_file")
-!DIR$ ATTRIBUTES DLLEXPORT :: extract_flows_from_cbc_file
 
 ! -- This function reads and accumulates flows (as read from a cell-by-cell flow term file)
 !    to a user-specified boundary condition.

--- a/pestutils/funcproc2.f90
+++ b/pestutils/funcproc2.f90
@@ -6,7 +6,6 @@ integer (kind=c_int) function calc_kriging_factors_2d(npts,ecs,ncs,zns,     &
                                    factorfile,factorfiletype,               &
                                    icount_interp)                           &
                  bind(C,name="calc_kriging_factors_2d")
-!DIR$ ATTRIBUTES DLLEXPORT :: calc_kriging_factors_2d
 
 ! -- This function calculates 2D kriging factors. Anisotropy, and anisotropy bearing
 !    can be spatially variable.
@@ -374,7 +373,6 @@ integer (kind=c_int) function calc_kriging_factors_auto_2d(npts,ecs,ncs,zns,  &
                                    factorfile,factorfiletype,                 &
                                    icount_interp)                             &
                  bind(C,name="calc_kriging_factors_auto_2d")
-!DIR$ ATTRIBUTES DLLEXPORT :: calc_kriging_factors_auto_2d
 
 ! -- This function calculates 2D kriging factors. Anisotropy, and anisotropy bearing
 !    can be spatially variable. Some variogram properties are determined automatically.
@@ -805,7 +803,6 @@ integer (kind=c_int) function calc_kriging_factors_3d(            &
                                    factorfile,factorfiletype,     &
                                    icount_interp)                 &
                  bind(C,name="calc_kriging_factors_3d")
-!DIR$ ATTRIBUTES DLLEXPORT :: calc_kriging_factors_3d
 
 ! -- This function calculates 3D kriging factors.
 
@@ -1315,7 +1312,6 @@ integer (kind=c_int) function krige_using_file(factorfile,factorfiletype,      &
                                                icount_interp,                  &
                                                meanval)                        &
                  bind(C,name="krige_using_file")
-!DIR$ ATTRIBUTES DLLEXPORT :: krige_using_file
 
 ! -- This function applies interpolation factors that are calculated by other functions.
 
@@ -1547,7 +1543,6 @@ integer (kind=c_int) function build_covar_matrix_2d(        &
                               nugget,aa,sill,anis,bearing,  &
                               ldcovmat,covmat)              &
                  bind(C,name="build_covar_matrix_2d")
-!DIR$ ATTRIBUTES DLLEXPORT :: build_covar_matrix_2d
 
 ! -- This function calculates a covariance matrix for a set of 2D pilot points.
 !    Variogram specifications can change with pilot point location.
@@ -1831,7 +1826,6 @@ integer (kind=c_int) function build_covar_matrix_3d(        &
                               bearing,dip,rake,             &
                               ldcovmat,covmat)              &
                  bind(C,name="build_covar_matrix_3d")
-!DIR$ ATTRIBUTES DLLEXPORT :: build_covar_matrix_3d
 
 ! -- This function calculates a covariance matrix for a set of 3D pilot points.
 !    Variogram specifications can change with pilot point location.
@@ -2163,7 +2157,6 @@ integer (kind=c_int) function calc_structural_overlay_factors(     &
                      factorfile,factorfiletype,                    &
                      icount_interp)                                &
                  bind(C,name="calc_structural_overlay_factors")
-!DIR$ ATTRIBUTES DLLEXPORT :: calc_structural_overlay_factors
 
 ! -- This function calculates interpolation/blending factors for structural overlay parameters.
 
@@ -2602,7 +2595,6 @@ integer (kind=c_int) function interpolate_blend_using_file(                    &
                                                sourceval,targval,              &
                                                icount_interp)                  &
                  bind(C,name="interpolate_blend_using_file")
-!DIR$ ATTRIBUTES DLLEXPORT :: interpolate_blend_using_file
 
 ! -- This function applies interpolation factors calculated by function calc_structural_overlay_factors.
 
@@ -2825,7 +2817,6 @@ integer (kind=c_int) function ipd_interpolate_2d(npts,             &
                                         transtype,                 &
                                         anis,bearing,invpow)       &
                  bind(C,name="ipd_interpolate_2d")
-!DIR$ ATTRIBUTES DLLEXPORT :: ipd_interpolate_2d
 
 ! -- This function undertakes 2D inverse-power-of-distance spatial interpolation.
 
@@ -3040,7 +3031,6 @@ integer (kind=c_int) function ipd_interpolate_3d(npts,                &
                                         bearing,dip,rake,             &
                                         invpow)                       &
                  bind(C,name="ipd_interpolate_3d")
-!DIR$ ATTRIBUTES DLLEXPORT :: ipd_interpolate_3d
 
 ! -- This function undertakes 3D inverse-power-of-distance spatial interpolation.
 
@@ -3294,7 +3284,6 @@ end function ipd_interpolate_3d
 
 integer (kind=c_int) function initialize_randgen(iseed) &
                  bind(C,name="initialize_randgen")
-!DIR$ ATTRIBUTES DLLEXPORT :: initialize_randgen
 
 ! -- Initialize the random number generator.
 
@@ -3325,7 +3314,6 @@ integer (kind=c_int) function fieldgen2d_sva(                &
                               transtype,avetype,power,       &
                               ldrand,nreal,randfield)        &
                  bind(C,name="fieldgen2d_sva")
-!DIR$ ATTRIBUTES DLLEXPORT :: fieldgen2d_sva
 
 ! -- This function generates stochastic fields based on a spatially varying variogram.
 ! -- It does this by 2D spatial convolution of an averaging function.
@@ -3590,7 +3578,6 @@ integer (kind=c_int) function fieldgen3d_sva(                &
                               transtype,avetype,power,       &
                               ldrand,nreal,randfield)        &
                  bind(C,name="fieldgen3d_sva")
-!DIR$ ATTRIBUTES DLLEXPORT :: fieldgen3d_sva
 
 ! -- This function generates 3D stochastic fields based on a spatially varying variogram.
 ! -- It does this by spatial convolution using an averaging function.

--- a/pestutils/function_interfaces.f90
+++ b/pestutils/function_interfaces.f90
@@ -7,7 +7,6 @@ module function_interfaces
     integer (kind=c_int) function inquire_modflow_binary_file_specs(            &
                          FileIn,FileOut,isim,itype,iprec,narray,ntime)          &
                      bind(C,name="inquire_modflow_binary_file_specs")
-    !DIR$ ATTRIBUTES DLLEXPORT :: inquire_modflow_binary_file_specs
        use iso_c_binding, only: c_int,c_char
        character (kind=c_char), intent(in)        :: FileIn(*)
        character (kind=c_char), intent(in)        :: FileOut(*)
@@ -20,7 +19,6 @@ module function_interfaces
 
     integer (kind=c_int) function retrieve_error_message(errormessage)             &
                     bind(c, name="retrieve_error_message")
-    !DIR$ ATTRIBUTES DLLEXPORT :: retrieve_error_message
        use iso_c_binding, only: c_int,c_char
        character (kind=c_char), intent(out) :: errormessage(*)
     end function retrieve_error_message
@@ -28,7 +26,6 @@ module function_interfaces
     integer (kind=c_int) function install_structured_grid                            &
                        (gridname,ncol,nrow,nlay,icorner,e0,n0,rotation,delr,delc)    &
                      bind(c,name="install_structured_grid")
-    !DIR$ ATTRIBUTES DLLEXPORT :: install_structured_grid
        use iso_c_binding, only: c_int,c_char,c_double
        character (kind=c_char), intent(in)  :: gridname(*)
        integer (kind=c_int), intent(in)     :: ncol,nrow,nlay
@@ -39,14 +36,12 @@ module function_interfaces
 
     integer (kind=c_int) function uninstall_structured_grid(gridname)                &
                      bind(c,name="uninstall_structured_grid")
-    !DIR$ ATTRIBUTES DLLEXPORT :: uninstall_structured_grid
        use iso_c_binding, only: c_int,c_char
        character (kind=c_char), intent(in)  :: gridname(*)
     end function uninstall_structured_grid
 
     integer (kind=c_int) function free_all_memory() &
                      bind(c,name="free_all_memory")
-    !DIR$ ATTRIBUTES DLLEXPORT :: free_all_memory
        use iso_c_binding, only: c_int
     end function free_all_memory
 
@@ -56,7 +51,6 @@ module function_interfaces
                              npts,ecoord,ncoord,layer,                       &
                              nproctime,simtime,simstate)                     &
                      bind(c,name="interp_from_structured_grid")
-    !DIR$ ATTRIBUTES DLLEXPORT :: interp_from_structured_grid
        use iso_c_binding, only: c_int,c_double,c_char
        character (kind=c_char), intent(in)  :: gridname(*)
        character (kind=c_char), intent(in)  :: depvarfile(*)
@@ -79,7 +73,6 @@ module function_interfaces
                              interpthresh,how_extrap,time_extrap,nointerpval,  &
                              nobs,obspoint,obstime,obssimval)                  &
                      bind(c,name="interp_to_obstime")
-    !DIR$ ATTRIBUTES DLLEXPORT :: interp_to_obstime
        use iso_c_binding, only: c_int,c_double,c_char
        integer(kind=c_int), intent(in)         :: nsimtime
        integer(kind=c_int), intent(in)         :: nproctime
@@ -100,7 +93,6 @@ module function_interfaces
                          gridname,grbfile,                            &
                          idis,ncells,ndim1,ndim2,ndim3)               &
                      bind(c,name="install_mf6_grid_from_file")
-    !DIR$ ATTRIBUTES DLLEXPORT :: install_mf6_grid_from_file
        use iso_c_binding, only: c_int,c_char
        character (kind=c_char,len=1), intent(in)  :: gridname(*)
        character (kind=c_char,len=1), intent(in)  :: grbfile(*)
@@ -111,7 +103,6 @@ module function_interfaces
 
     integer (kind=c_int) function uninstall_mf6_grid(gridname)         &
                      bind(c,name="uninstall_mf6_grid")
-    !DIR$ ATTRIBUTES DLLEXPORT :: uninstall_mf6_grid
        use iso_c_binding, only: c_int,c_char
        character (kind=c_char,len=1), intent(in)  :: gridname(*)
     end function uninstall_mf6_grid
@@ -122,7 +113,6 @@ module function_interfaces
                               factorfile, factorfiletype,              &
                               blnfile,interp_success)                  &
                      bind(c,name="calc_mf6_interp_factors")
-    !DIR$ ATTRIBUTES DLLEXPORT :: calc_mf6_interp_factors
        use iso_c_binding, only: c_int,c_double,c_char
        character (kind=c_char,len=1), intent(in)   :: gridname(*)
        integer(kind=c_int), intent(in)             :: npts
@@ -139,7 +129,6 @@ module function_interfaces
                          ntime,vartype,interpthresh,reapportion,nointerpval,   &
                          npts,nproctime,simtime,simstate)                      &
                      bind(c,name="interp_from_mf6_depvar_file")
-    !DIR$ ATTRIBUTES DLLEXPORT :: interp_from_mf6_depvar_file
            use iso_c_binding, only: c_int,c_char,c_double
            character(kind=c_char,len=1), intent(in)   :: depvarfile(*)
            character(kind=c_char,len=1), intent(in)   :: factorfile(*)
@@ -162,7 +151,6 @@ module function_interfaces
                          ntime,nproctime,                          &
                          timestep,stressperiod,simtime,simflow)    &
                      bind(c,name="extract_flows_from_cbc_file")
-    !DIR$ ATTRIBUTES DLLEXPORT :: extract_flows_from_cbc_file
        use iso_c_binding, only: c_int,c_char,c_double
        character (kind=c_char,len=1), intent(in)  :: cbcfile(*)
        character (kind=c_char,len=1), intent(in)  :: flowtype(*)
@@ -196,7 +184,6 @@ module function_interfaces
                             factorfile,factorfiletype,            &
                             icount_interp)                        &
                      bind(c,name="calc_kriging_factors_2d")
-    !DIR$ ATTRIBUTES DLLEXPORT :: calc_kriging_factors_2d
        use iso_c_binding, only: c_int,c_char,c_double
        integer(kind=c_int), intent(in)           :: npts
        real(kind=c_double), intent(in)           :: ecs(npts),ncs(npts)
@@ -224,7 +211,6 @@ module function_interfaces
                                    factorfile,factorfiletype,       &
                                    icount_interp)                   &
                      bind(c,name="calc_kriging_factors_auto_2d")
-    !DIR$ ATTRIBUTES DLLEXPORT :: calc_kriging_factors_auto_2d
        use iso_c_binding, only: c_int,c_char,c_double
        integer(kind=c_int), intent(in)           :: npts
        real(kind=c_double), intent(in)           :: ecs(npts),ncs(npts)
@@ -248,7 +234,6 @@ module function_interfaces
                          icount_interp,                  &
                          meanval)                        &
                      bind(c,name="krige_using_file")
-    !DIR$ ATTRIBUTES DLLEXPORT :: krige_using_file
        use iso_c_binding, only: c_int,c_char,c_double
        character (kind=c_char,len=1), intent(in) :: factorfile(*)
        integer(kind=c_int), intent(in)           :: factorfiletype
@@ -275,7 +260,6 @@ module function_interfaces
                                    factorfile,factorfiletype,     &
                                    icount_interp)                 &
                      bind(c,name="calc_kriging_factors_3d")
-    !DIR$ ATTRIBUTES DLLEXPORT :: calc_kriging_factors_3d
        use iso_c_binding, only: c_int,c_char,c_double
        integer(kind=c_int), intent(in)         :: npts
        real(kind=c_double), intent(in)         :: ecs(npts),ncs(npts),zcs(npts)
@@ -306,7 +290,6 @@ module function_interfaces
                               nugget,aa,sill,anis,bearing,  &
                               ldcovmat,covmat)              &
                      bind(c,name="build_covar_matrix_2d")
-    !DIR$ ATTRIBUTES DLLEXPORT :: build_covar_matrix_2d
        use iso_c_binding, only: c_int,c_double
        integer(kind=c_int), intent(in)         :: npts
        real(kind=c_double), intent(in)         :: ec(npts),nc(npts)
@@ -329,7 +312,6 @@ module function_interfaces
                                   bearing,dip,rake,             &
                                   ldcovmat,covmat)              &
                      bind(c,name="build_covar_matrix_3d")
-    !DIR$ ATTRIBUTES DLLEXPORT :: build_covar_matrix_3d
        use iso_c_binding, only: c_int,c_double
        integer(kind=c_int), intent(in)         :: npts
        real(kind=c_double), intent(in)         :: ec(npts),nc(npts),zc(npts)
@@ -353,7 +335,6 @@ module function_interfaces
                          factorfile,factorfiletype,                    &
                          icount_interp)                                &
                      bind(c,name="calc_structural_overlay_factors")
-    !DIR$ ATTRIBUTES DLLEXPORT :: calc_structural_overlay_factors
        use iso_c_binding, only: c_int,c_char,c_double
        integer(kind=c_int), intent(in)           :: npts
        real(kind=c_double), intent(in)           :: ecs(npts),ncs(npts)
@@ -377,7 +358,6 @@ module function_interfaces
                                  sourceval,targval,                &
                                  icount_interp)                    &
                     bind(c,name="interpolate_blend_using_file")
-   !DIR$ ATTRIBUTES DLLEXPORT :: interpolate_blend_using_file
        use iso_c_binding, only: c_int,c_char,c_double
        character (kind=c_char,len=1), intent(in) :: factorfile(*)
        integer(kind=c_int), intent(in)           :: factorfiletype
@@ -398,7 +378,6 @@ module function_interfaces
                               transtype,                 &
                               anis,bearing,invpow)       &
                     bind(c,name="ipd_interpolate_2d")
-   !DIR$ ATTRIBUTES DLLEXPORT :: ipd_interpolate_2d
        use iso_c_binding, only: c_int,c_double
        integer(kind=c_int), intent(in)           :: npts
        real(kind=c_double), intent(in)           :: ecs(npts),ncs(npts)
@@ -424,7 +403,6 @@ module function_interfaces
                         bearing,dip,rake,             &
                         invpow)                       &
                     bind(c,name="ipd_interpolate_3d")
-   !DIR$ ATTRIBUTES DLLEXPORT :: ipd_interpolate_3d
        use iso_c_binding, only: c_int,c_double
        integer(kind=c_int), intent(in)    :: npts
        real(kind=c_double), intent(in)    :: ecs(npts),ncs(npts),zcs(npts)
@@ -442,7 +420,6 @@ module function_interfaces
 
    integer (kind=c_int) function initialize_randgen(iseed) &
                     bind(c,name="initialize_randgen")
-   !DIR$ ATTRIBUTES DLLEXPORT :: initialize_randgen
        use iso_c_binding, only: c_int
        integer(kind=c_int), intent(in)    :: iseed
    end function initialize_randgen
@@ -454,7 +431,6 @@ module function_interfaces
                               transtype,avetype,power,       &
                               ldrand,nreal,randfield)        &
                     bind(c,name="fieldgen2d_sva")
-   !DIR$ ATTRIBUTES DLLEXPORT :: fieldgen2d_sva
        use iso_c_binding, only: c_int,c_double
        integer(kind=c_int), intent(in)   :: nnode
        real(kind=c_double), intent(in)   :: ec(nnode),nc(nnode)
@@ -483,7 +459,6 @@ module function_interfaces
                               transtype,avetype,power,       &
                               ldrand,nreal,randfield)        &
                     bind(c,name="fieldgen3d_sva")
-   !DIR$ ATTRIBUTES DLLEXPORT :: fieldgen3d_sva
        use iso_c_binding, only: c_int,c_double
        integer(kind=c_int), intent(in)   :: nnode
        real(kind=c_double), intent(in)   :: ec(nnode),nc(nnode),zc(nnode)

--- a/pestutils/meson.build
+++ b/pestutils/meson.build
@@ -14,6 +14,7 @@ lib_sources = files(
 
 lib = shared_library('pestutils', lib_sources,
   name_prefix: host_machine.system() == 'windows' ? '': 'lib',
+  vs_module_defs: 'pestutils.def',
   install: true)
 
 # Set RUNPATH/RPATH for install_rpath for only Linux and macOS

--- a/pestutils/pestutils.def
+++ b/pestutils/pestutils.def
@@ -1,0 +1,29 @@
+EXPORTS
+   LENFILENAME DATA
+   LENMESSAGE DATA
+   LENGRIDNAME DATA
+   inquire_modflow_binary_file_specs
+   retrieve_error_message
+   install_structured_grid
+   uninstall_structured_grid
+   free_all_memory
+   interp_from_structured_grid
+   interp_to_obstime
+   install_mf6_grid_from_file
+   uninstall_mf6_grid
+   calc_mf6_interp_factors
+   interp_from_mf6_depvar_file
+   extract_flows_from_cbc_file
+   calc_kriging_factors_2d
+   calc_kriging_factors_auto_2d
+   krige_using_file
+   calc_kriging_factors_3d
+   build_covar_matrix_2d
+   build_covar_matrix_3d
+   calc_structural_overlay_factors
+   interpolate_blend_using_file
+   ipd_interpolate_2d
+   ipd_interpolate_3d
+   initialize_randgen
+   fieldgen2d_sva
+   fieldgen3d_sva


### PR DESCRIPTION
This will properly export data symbols from pestutils/dimvar_c.f90 to pestutils.dll created by Intel Fortran on Windows.