### PR TITLE
CI: change scheduled run to run at 8:42 every other day

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on: 
   schedule:
-    - cron: '0 8 * * *' # run at 8 AM UTC (12 AM PST, 8 PM NZST)
+    - cron: '42 8 2-30/2 * *' # At 08:42 UTC on every 2nd day-of-month
   push:
   pull_request:
 
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ["3.8", "3.11"]  # run lower and upper versions
 
     steps:


### PR DESCRIPTION
The scheduled CI run stopped two months ago, not sure exactly why.

Guidance docs [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) suggest that "The `schedule` event can be delayed during periods of high loads of GitHub Actions workflow runs... To decrease the chance of delay, schedule your workflow to run at a different time of the hour."

Furthermore, this will need to be put into the `main` default branch to work correctly. (To be honest, I'd rather do-away with `develop` git-flow branch, and just use one `main` branch for development).