### PR TITLE
RLS: update cibuildwheel, use macos-12 image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,18 +19,33 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-11]
+        include:
+        - os: ubuntu-22.04
+          arch: x86_64
+        - os: ubuntu-22.04
+          arch: aarch64
+        - os: windows-2022
+          arch: AMD64
+        - os: macos-11
+          arch: x86_64
+          macosx_deployment_target: "11.0"
+          cmake_osx_architectures: x86_64
+        - os: macos-14
+          arch: arm64
+          macosx_deployment_target: "14.0"
+          cmake_osx_architectures: arm64
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        if: runner.os == 'Linux' && matrix.arch == 'aarch64'
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
@@ -55,11 +70,19 @@ jobs:
           bash scripts/build_lib.sh
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.18.0
+        env:
+          CIBW_BUILD: "cp39-*"  # pick one version
+          CIBW_SKIP: "*-musllinux*"
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_ENVIRONMENT_MACOS:
+            FC=gfortran-13
+            MACOSX_DEPLOYMENT_TARGET='${{ matrix.macosx_deployment_target }}'
+            CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,32 +57,27 @@ version = {attr = "pypestutils.version.__version__"}
 include = ["pypestutils", "pypestutils.*"]
 
 [tool.cibuildwheel]
-build = "cp38-*"  # pick one; see also [project.requires-python]
-skip = "*-musllinux*"
-build-verbosity = "3"
+build-verbosity = "2"
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-requires = "tox"
 test-command = "tox --conf {project} --installpkg {wheel}"
 
 [tool.cibuildwheel.linux]
-archs = ["x86_64", "aarch64"]
 before-build = [
-    "pip install meson ninja",
+    "pip install meson ninja wheel",
     "bash {project}/scripts/build_lib.sh",
 ]
 test-skip = "*aarch64"  # slow!
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64"]  # , "arm64"] - need either native host or fortran cross-compiler
-environment = { MACOSX_DEPLOYMENT_TARGET="10.9", FC="gfortran-13" }
+# see CIBW_ENVIRONMENT_MACOS in release.yml
 before-build = [
-    "pip install meson ninja",
+    "pip install meson ninja wheel",
     "bash {project}/scripts/build_lib.sh",
 ]
-test-skip = "*-macosx_arm64"
 
 [tool.cibuildwheel.windows]
-archs = ["AMD64"]
+before-build = "pip install wheel"
 
 [tool.isort]
 profile = "black"

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -2,7 +2,6 @@
 import logging
 import pytest
 import os
-import pyemu
 
 
 # @pytest.mark.parametrize(
@@ -29,6 +28,8 @@ import pyemu
 #     return
 
 def test_notebooks():
+    import pyemu
+
     nb_dir = os.path.join("examples")
     nb_files = [f for f in os.listdir(nb_dir) if f.endswith(".ipynb")]
     for nb_file in nb_files:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{39,310,311}
+env_list = py{38,39,310,311,312}
 
 [testenv]
 description = run unit tests
@@ -14,4 +14,4 @@ install_command =
 ignore_errors = True
 ignore_outcome = True
 commands =
-    pytest {posargs:tests}
+    pytest {posargs:tests} -k "not test_notebooks"


### PR DESCRIPTION
Resolve cibuildwheel on Windows, and use same macos image as testing.