### PR TITLE
CI/RLS: update cibuildwheel workflow and macos images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Build wheels
 
 on:
+  schedule:
+    - cron: '42 8 2-30/2 * *' # At 08:42 UTC on every 2nd day-of-month
   pull_request:
     paths:  # only run this with PRs that touch these files
       - ".github/workflows/release.yml"
@@ -31,9 +33,9 @@ jobs:
           arch: aarch64
         - os: windows-2022
           arch: AMD64
-        - os: macos-11
+        - os: macos-13
           arch: x86_64
-          macosx_deployment_target: "11.0"
+          macosx_deployment_target: "13.0"
           cmake_osx_architectures: x86_64
         - os: macos-14
           arch: arm64
@@ -70,10 +72,8 @@ jobs:
           bash scripts/build_lib.sh
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.0
+        uses: pypa/cibuildwheel@v2.19.2
         env:
-          CIBW_BUILD: "cp39-*"  # pick one version
-          CIBW_SKIP: "*-musllinux*"
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT_MACOS:
             FC=gfortran-13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
 requires-python = ">=3.8"
@@ -57,10 +58,14 @@ version = {attr = "pypestutils.version.__version__"}
 include = ["pypestutils", "pypestutils.*"]
 
 [tool.cibuildwheel]
-build-verbosity = "2"
+build = "cp39-*"
+build-verbosity = 3
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-requires = "tox"
 test-command = "tox --conf {project} --installpkg {wheel}"
+test-skip = [
+    "*-musllinux*",
+]
 
 [tool.cibuildwheel.linux]
 before-build = [

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ env_list = py{38,39,310,311,312}
 [testenv]
 description = run unit tests
 deps =
-    pytest
+    pytest>=6
     numpy
     pandas
 install_command =
@@ -14,4 +14,4 @@ install_command =
 ignore_errors = True
 ignore_outcome = True
 commands =
-    pytest {posargs:tests}
+    pytest --import-mode=importlib {posargs:tests}


### PR DESCRIPTION
This PR updates cibuildwheel and macos images used for CI and release. Also add a cron schedule to re-run the release workflow to guard against upstream changes.

Changes to tox's `--import-mode=importlib` ensure that the built-wheel is tested, and not the local build.