### PR TITLE
Set minimum Python 3.9, test 3.13, update GHA components

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,10 @@ jobs:
         shell: msys2 {0}
         env:
           LDFLAGS: -static-libgcc -static-libgfortran -static-libquadmath -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive
-        run: |
-          bash scripts/build_lib.sh
+        run: bash scripts/build_lib.sh
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT_MACOS:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
-        python-version: ["3.8", "3.11"]  # run lower and upper versions
+        os: [ubuntu-latest, macos-14, windows-latest]
+        python-version: ["3.9", "3.13"]  # run lower and upper versions
 
     steps:
       - uses: actions/checkout@v4
@@ -25,8 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Update pip
-        run: |
-          python -m pip install --upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install MinGW-w64 tools (Windows)
         if: runner.os == 'Windows'
@@ -42,7 +41,7 @@ jobs:
 
       - name: Install GCC Fortran (macOS)
         if: runner.os == 'macOS'
-        uses: awvwgk/setup-fortran@main
+        uses: fortran-lang/setup-fortran@v1
         with:
           compiler: gcc
           version: 11
@@ -70,20 +69,16 @@ jobs:
         shell: msys2 {0}
         env:
           LDFLAGS: -static-libgcc -static-libgfortran -static-libquadmath -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive
-        run: |
-          bash scripts/build_lib.sh
+        run: bash scripts/build_lib.sh
 
       - name: Build pestutils (non-Windows)
         if: runner.os != 'Windows'
-        run: |
-          bash scripts/build_lib.sh
+        run: bash scripts/build_lib.sh
 
       - name: Install package
-        run: |
-          pip install .[test,optional]
+        run: pip install .[test,optional]
 
       - name: Run tests
-        run: |
-          pytest -v
+        run: pytest -v
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    name: Run tests on ${{ matrix.os }} Py${{ matrix.python }}
+    name: Tests on ${{ matrix.os }} Python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.9", "3.13"]  # run lower and upper versions
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,14 @@ classifiers = [
     "Programming Language :: Fortran",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "pandas",
@@ -65,17 +65,9 @@ test-requires = "tox"
 test-command = "tox --conf {project} --installpkg {wheel}"
 test-skip = [
     "*-musllinux*",
+    "*aarch64",  # slow!
 ]
-
-[tool.cibuildwheel.linux]
-before-build = [
-    "pip install meson ninja wheel",
-    "bash {project}/scripts/build_lib.sh",
-]
-test-skip = "*aarch64"  # slow!
-
-[tool.cibuildwheel.macos]
-# see CIBW_ENVIRONMENT_MACOS in release.yml
+# see also CIBW_ENVIRONMENT_MACOS in release.yml
 before-build = [
     "pip install meson ninja wheel",
     "bash {project}/scripts/build_lib.sh",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{38,39,310,311,312}
+env_list = py{39,310,311,312,313}
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
There are a number changes in this PR:

- Set the minimum Python 3.9, dropping 3.8 which reached it's EOL October 2024
- Start testing Python 3.13, released October 2024
- Upgrade deprecated `macos-12` to `-13`
- Use https://github.com/fortran-lang/setup-fortran and update cibuildwheel actions