### PR TITLE
CI: Use uv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,11 @@
 name: Tests
 
-on: 
+on:
   schedule:
     - cron: '42 8 2-30/2 * *' # At 08:42 UTC on every 2nd day-of-month
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   tests:
@@ -20,12 +21,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Update pip
-        run: python -m pip install --upgrade pip
 
       - name: Install MinGW-w64 tools (Windows)
         if: runner.os == 'Windows'
@@ -44,25 +42,10 @@ jobs:
         uses: fortran-lang/setup-fortran@v1
         with:
           compiler: gcc
-          version: 11
+          version: 13
 
-      - name: Install build dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          pip install meson ninja pandas numpy matplotlib pyemu flopy jupyter notebook nbconvert
-
-      - name: Install build dependencies (macOS)
-        if: runner.os == 'Windows'
-        run: |
-          pip install meson ninja pandas numpy matplotlib pyemu flopy jupyter notebook nbconvert
-
-
-      - name: Install build dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gfortran
-          pip install meson ninja pandas numpy matplotlib pyemu flopy jupyter notebook nbconvert
+      - name: Install build requirements
+        run: uv pip install meson ninja
 
       - name: Build pestutils (Windows)
         if: runner.os == 'Windows'
@@ -75,10 +58,10 @@ jobs:
         if: runner.os != 'Windows'
         run: bash scripts/build_lib.sh
 
-      - name: Install package
-        run: pip install .[test,optional]
+      - name: Install package and all extras
+        run: uv sync --all-extras
 
       - name: Run tests
-        run: pytest -v
+        run: uv run pytest -v
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 optional = [
     "flopy",
+    "jupyter",
     "pyemu",
 ]
 test = [

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -3,8 +3,12 @@
 from pathlib import Path
 from subprocess import run
 
-import nbformat
 import pytest
+
+try:
+    import nbformat
+except ImportError:
+    pytest.skip("requires nbformat", allow_module_level=True)
 
 examples_dir = Path(__file__).parent.parent / "examples"
 
@@ -15,7 +19,7 @@ def test_notebooks(nb_file):
         nb = nbformat.read(f, as_version=4)
     for cell in nb["cells"]:
         for line in cell["source"].splitlines():
-            if line.startswith("import "):
+            if line.startswith("import ") and "ppu_helpers" not in line:
                 module = line.split()[1]
                 pytest.importorskip(module)
 


### PR DESCRIPTION
This replaced pip with uv, which is much faster. See docs [here](https://docs.astral.sh/uv/guides/integration/github/).

It also adds jupyter to optional extra, and fixes a bad skip with test_notebooks.