### PR TITLE
BLD/CI: fix build, assuming OSTYPE may also be 'cygwin'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: mingw64
           path-type: inherit
           install: >-
             mingw-w64-x86_64-gcc-fortran

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: mingw64
           path-type: inherit
           install: >-
             mingw-w64-x86_64-gcc-fortran

--- a/scripts/build_lib.sh
+++ b/scripts/build_lib.sh
@@ -4,11 +4,13 @@ set -e
 # always run from top of repo
 cd $(dirname $0)/..
 
+echo "Running $0 for \$OSTYPE=$OSTYPE ..."
+
 # this needs bash
 case "$OSTYPE" in
   darwin*)  libname=lib/libpestutils.dylib ;;
   linux*)   libname=lib/libpestutils.so ;;
-  msys* )   libname=bin/pestutils.dll ;;
+  msys*|cygwin ) libname=bin/pestutils.dll ;;
   *) echo "unknown \$OSTYPE: $OSTYPE" && exit 1 ;;
 esac
 


### PR DESCRIPTION
This fixes an issue from https://github.com/msys2/setup-msys2 that first appeared a few months ago, where `$OSTYPE` changed from `msys` to `cygwin`.