### PR TITLE
Drop Python 3.9 and Intel macOS builds, add Python 3.14 testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,17 +33,13 @@ jobs:
           arch: aarch64
         - os: windows-2022
           arch: AMD64
-        - os: macos-13
-          arch: x86_64
-          macosx_deployment_target: "13.0"
-          cmake_osx_architectures: x86_64
         - os: macos-14
           arch: arm64
           macosx_deployment_target: "14.0"
           cmake_osx_architectures: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.arch == 'aarch64'
@@ -71,7 +67,7 @@ jobs:
         run: bash scripts/build_lib.sh
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.2.1
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT_MACOS:
@@ -79,7 +75,7 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET='${{ matrix.macosx_deployment_target }}'
             CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
@@ -88,12 +84,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -108,7 +104,7 @@ jobs:
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           # unpacks all CIBW artifacts into dist/
           pattern: cibw-*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.13"]  # run lower and upper versions
+        python-version: ["3.10", "3.14"]  # run lower and upper versions
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
+          activate-environment: "true"
 
       - name: Install MinGW-w64 tools (Windows)
         if: runner.os == 'Windows'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
     - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.3
+    rev: v0.14.2
     hooks:
       # Run the linter
       - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,25 +12,24 @@ authors = [
 readme = "README.md"
 description = "PEST utilities for MODFLOW"
 keywords = ["PEST", "MODFLOW", "groundwater", "model"]
-license = {text = "Unlicense"}
+license = "Unlicense"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: The Unlicense (Unlicense)",
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Fortran",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "pandas",
@@ -59,7 +58,7 @@ version = {attr = "pypestutils.version.__version__"}
 include = ["pypestutils", "pypestutils.*"]
 
 [tool.cibuildwheel]
-build = "cp39-*"
+build = "cp310-*"
 build-verbosity = 3
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-requires = "tox"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{39,310,311,312,313}
+env_list = py{310,311,312,313,314}
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
This PR does a few maintenance tasks:

- Python 3.9 is EOL, so remove testing this version
- Add support/tests for Python 3.14
- Intel macOS images (`macos-13`) are about to be removed, so stop building these wheels -- some users may need to rely on v0.3.0 binary wheels [here](https://pypi.org/project/pypestutils/0.3.0/#files)
- Upgrade a few GitHub actions versions