### PR TITLE
Miscellaneous improvements to package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,12 +113,8 @@ ipython_config.py
 # pyenv
 .python-version
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
+# lock files (uv, pixi, and others)
+*.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
     - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.15.20
     hooks:
       # Run the linter
       - id: ruff-check

--- a/BUILD.md
+++ b/BUILD.md
@@ -12,7 +12,7 @@ The following sections describe how to build a shared library of `pestutils`, wh
 
 Then to install a development version of pypestutils use:
 ```bash
-pip install -e .
+pip install -e . --group dev
 ```
 
 ## Build pestutils on Linux / macOS / Windows (MSYS2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77", "wheel"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -41,13 +41,26 @@ optional = [
     "jupyter",
     "pyemu",
 ]
-test = [
+
+[dependency-groups]
+dev = [
+    "pre-commit",
+    "ruff",
+    "tox>=4.22",
+    "wheel",
+    {include-group = "tests"},
+]
+tests = [
     "pytest",
     "pytest-timeout",
 ]
 
 [project.urls]
 Repository = "https://github.com/pypest/pypestutils"
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+testpaths = ["tests"]
 
 [tool.setuptools]
 include-package-data = false

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@
 import os
 
 from setuptools import setup
+from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
 from setuptools.command.install import install
 from setuptools.dist import Distribution
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 # current working directory of this setup.py file
 _cwd = os.path.abspath(os.path.split(__file__)[0])

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,13 @@
 [tox]
 requires =
-    tox>=4
+    tox>=4.22
 env_list = py{310,311,312,313,314}
 
 [testenv]
 description = run unit tests
-deps =
-    pytest>=6
-    numpy
-    pandas
+dependency_groups = tests
 install_command =
     python -I -m pip install --only-binary=:all: {opts} {packages}
 ignore_errors = True
 ignore_outcome = True
-commands =
-    pytest --import-mode=importlib {posargs:tests}
+commands = pytest


### PR DESCRIPTION
This is a suite of miscellaneous improvements to the package. No code refactors here. Here are the details:

- Ignore lock files from (e.g.) uv, pixi and others. I don't feel these add value, and wouldn't want it accidentally included.
- Use dependency groups ([PEP 735](https://peps.python.org/pep-0735/)) to help development.
- Require more recent setuptools for license metadata changes ([PEP 639](https://peps.python.org/pep-0639/)) and inclusion of `bdist_wheel`
- Use more recent version of tox to use dependency groups
- Configure pytest options in one place